### PR TITLE
refactor: 상품 엔티티 마이그레이션

### DIFF
--- a/src/main/kotlin/com/wl2c/elswhere/global/base/BaseEntity.kt
+++ b/src/main/kotlin/com/wl2c/elswhere/global/base/BaseEntity.kt
@@ -1,0 +1,22 @@
+package com.wl2c.elswhere.global.base
+
+import jakarta.persistence.Column
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.MappedSuperclass
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDateTime
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener::class)
+class BaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private val createdAt: LocalDateTime? = null
+
+    @LastModifiedDate
+    private var lastModifiedAt: LocalDateTime? = null
+
+}

--- a/src/main/kotlin/com/wl2c/elswhere/product/model/IssuerState.kt
+++ b/src/main/kotlin/com/wl2c/elswhere/product/model/IssuerState.kt
@@ -1,0 +1,13 @@
+package com.wl2c.elswhere.domain.product.model
+
+enum class IssuerState {
+    /**
+     * 활성화
+     */
+    ACTIVE,
+
+    /**
+     * 비 활성화
+     */
+    INACTIVE
+}

--- a/src/main/kotlin/com/wl2c/elswhere/product/model/MaturityEvaluationDateType.kt
+++ b/src/main/kotlin/com/wl2c/elswhere/product/model/MaturityEvaluationDateType.kt
@@ -1,0 +1,18 @@
+package com.wl2c.elswhere.domain.product.model
+
+enum class MaturityEvaluationDateType {
+    /**
+     * 한 개의 만기 평가일
+     */
+    SINGLE,
+
+    /**
+     * 여러 개의 만기 평가일
+     */
+    MULTIPLE,
+
+    /**
+     * 파악되지 않음
+     */
+    UNKNOWN
+}

--- a/src/main/kotlin/com/wl2c/elswhere/product/model/ProductState.kt
+++ b/src/main/kotlin/com/wl2c/elswhere/product/model/ProductState.kt
@@ -1,0 +1,13 @@
+package com.wl2c.elswhere.domain.product.model
+
+enum class ProductState {
+    /**
+     * 활성화
+     */
+    ACTIVE,
+
+    /**
+     * 비 활성화
+     */
+    INACTIVE
+}

--- a/src/main/kotlin/com/wl2c/elswhere/product/model/ProductType.kt
+++ b/src/main/kotlin/com/wl2c/elswhere/product/model/ProductType.kt
@@ -1,0 +1,23 @@
+package com.wl2c.elswhere.domain.product.model
+
+enum class ProductType {
+    /**
+     * 스텝 다운
+     */
+    STEP_DOWN,
+
+    /**
+     * 리자드 스텝 다운
+     */
+    LIZARD,
+
+    /**
+     * 월지급식
+     */
+    MONTHLY_PAYMENT,
+
+    /**
+     * 기타
+     */
+    ETC
+}

--- a/src/main/kotlin/com/wl2c/elswhere/product/model/UnderlyingAssetType.kt
+++ b/src/main/kotlin/com/wl2c/elswhere/product/model/UnderlyingAssetType.kt
@@ -1,0 +1,21 @@
+package com.wl2c.elswhere.domain.product.model
+
+/**
+ * 기초자산 유형
+ */
+enum class UnderlyingAssetType {
+    /**
+     * 주가 지수
+     */
+    INDEX,
+
+    /**
+     * 종목
+     */
+    STOCK,
+
+    /**
+     * 혼합
+     */
+    MIX
+}

--- a/src/main/kotlin/com/wl2c/elswhere/product/model/entity/EarlyRepaymentEvaluationDates.kt
+++ b/src/main/kotlin/com/wl2c/elswhere/product/model/entity/EarlyRepaymentEvaluationDates.kt
@@ -1,0 +1,24 @@
+package com.wl2c.elswhere.domain.product.model.entity
+
+import com.wl2c.elswhere.global.base.BaseEntity
+import jakarta.persistence.*
+import java.time.LocalDate
+
+@Entity
+class EarlyRepaymentEvaluationDates(
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id")
+    var product: Product,
+
+    @Column(nullable = false)
+    var earlyRepaymentEvaluationDate: LocalDate
+
+): BaseEntity() {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "early_repayment_evaluation_dates_id")
+    val id: Long? = null
+
+}

--- a/src/main/kotlin/com/wl2c/elswhere/product/model/entity/Issuer.kt
+++ b/src/main/kotlin/com/wl2c/elswhere/product/model/entity/Issuer.kt
@@ -1,0 +1,25 @@
+package com.wl2c.elswhere.domain.product.model.entity
+
+import com.wl2c.elswhere.domain.product.model.IssuerState
+import com.wl2c.elswhere.global.base.BaseEntity
+import jakarta.persistence.*
+import org.hibernate.annotations.ColumnDefault
+
+@Entity
+class Issuer(
+
+    @Column(nullable = false)
+    val issuerName: String,
+
+    @ColumnDefault("'INACTIVE'")
+    @Enumerated(EnumType.STRING)
+    var issuerState: IssuerState
+
+): BaseEntity() {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "issuer_id")
+    val id: Long? = null
+
+}

--- a/src/main/kotlin/com/wl2c/elswhere/product/model/entity/Product.kt
+++ b/src/main/kotlin/com/wl2c/elswhere/product/model/entity/Product.kt
@@ -1,0 +1,111 @@
+package com.wl2c.elswhere.domain.product.model.entity
+
+import com.wl2c.elswhere.domain.product.model.MaturityEvaluationDateType
+import com.wl2c.elswhere.domain.product.model.ProductState
+import com.wl2c.elswhere.domain.product.model.ProductType
+import com.wl2c.elswhere.domain.product.model.UnderlyingAssetType
+import com.wl2c.elswhere.global.base.BaseEntity
+import jakarta.persistence.*
+import lombok.AccessLevel
+import lombok.Builder
+import lombok.Getter
+import lombok.NoArgsConstructor
+import org.hibernate.annotations.ColumnDefault
+import java.math.BigDecimal
+import java.time.LocalDate
+
+@Entity
+class Product @Builder private constructor(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "product_id")
+    val id: Long? = null,
+
+    @Column(nullable = false)
+    var issuer: String,
+
+    @Column(nullable = false)
+    var name: String,
+
+    var issueNumber: Int?,
+
+    @Column(nullable = false)
+    var equities: String,
+
+    var equityCount: Int,
+
+    var knockIn: Int?,
+
+    @Column(nullable = false)
+    var issuedDate: LocalDate,
+
+    @Column(nullable = false)
+    var maturityEvaluationDate: LocalDate,
+
+    @Column(nullable = false)
+    @ColumnDefault("'UNKNOWN'")
+    @Enumerated(EnumType.STRING)
+    var maturityEvaluationDateType: MaturityEvaluationDateType,
+
+    @Column(nullable = false)
+    var maturityDate: LocalDate,
+
+    @Column(nullable = false, precision = 8, scale = 5)
+    var yieldIfConditionsMet: BigDecimal,
+
+    @Column(nullable = false, precision = 8, scale = 5)
+    var maximumLossRate: BigDecimal,
+
+    @Column(nullable = false)
+    var subscriptionStartDate: LocalDate,
+
+    @Column(nullable = false)
+    var subscriptionEndDate: LocalDate,
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    var type: ProductType,
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    var underlyingAssetType: UnderlyingAssetType,
+
+    @Column(nullable = false)
+    var productFullInfo: String,
+
+    var productInfo: String?,
+
+    @Column(nullable = false)
+    var link: String,
+
+    @Column(nullable = false)
+    var remarks: String,
+
+    var summaryInvestmentProspectusLink: String?,
+
+    var earlyRepaymentEvaluationDates: String?,
+
+    var volatilites: String?,
+
+    var initialBasePriceEvaluationDate: LocalDate?,
+
+    @Column(nullable = false)
+    @ColumnDefault("'INACTIVE'")
+    @Enumerated(EnumType.STRING)
+    var productState: ProductState,
+
+): BaseEntity() {
+
+    @OneToMany(mappedBy = "product", cascade = [CascadeType.ALL], orphanRemoval = true)
+    val productTickerSymbols: MutableList<ProductTickerSymbol> = mutableListOf()
+
+    fun setInActiveProductState() {
+        productState = ProductState.INACTIVE
+    }
+
+    fun setActiveProductState() {
+        productState = ProductState.ACTIVE
+    }
+
+}

--- a/src/main/kotlin/com/wl2c/elswhere/product/model/entity/ProductEquityVolatility.kt
+++ b/src/main/kotlin/com/wl2c/elswhere/product/model/entity/ProductEquityVolatility.kt
@@ -1,0 +1,24 @@
+package com.wl2c.elswhere.domain.product.model.entity
+
+import com.wl2c.elswhere.global.base.BaseEntity
+import jakarta.persistence.*
+import java.math.BigDecimal
+
+@Entity
+class ProductEquityVolatility(
+
+    @OneToOne
+    @MapsId
+    @JoinColumn(name = "product_equity_volatility_id")
+    var productTickerSymbol: ProductTickerSymbol,
+
+    @Column(nullable = false, scale = 16)
+    var volatility: BigDecimal
+
+): BaseEntity() {
+
+    @Id
+    @Column(name = "product_equity_volatility_id")
+    val id: Long? = null
+
+}

--- a/src/main/kotlin/com/wl2c/elswhere/product/model/entity/ProductTickerSymbol.kt
+++ b/src/main/kotlin/com/wl2c/elswhere/product/model/entity/ProductTickerSymbol.kt
@@ -1,0 +1,31 @@
+package com.wl2c.elswhere.domain.product.model.entity
+
+import com.wl2c.elswhere.global.base.BaseEntity
+import jakarta.persistence.*
+
+@Entity
+class ProductTickerSymbol(
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id")
+    var product: Product,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ticker_symbol_id")
+    var tickerSymbol: TickerSymbol
+
+): BaseEntity() {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "product_ticker_symbol_id")
+    val id: Long? = null
+
+    @Column(nullable = false)
+    var equityName: String = tickerSymbol.equityName
+
+    @OneToOne(mappedBy = "productTickerSymbol")
+    @PrimaryKeyJoinColumn
+    val productEquityVolatility: ProductEquityVolatility? = null
+
+}

--- a/src/main/kotlin/com/wl2c/elswhere/product/model/entity/TickerSymbol.kt
+++ b/src/main/kotlin/com/wl2c/elswhere/product/model/entity/TickerSymbol.kt
@@ -1,0 +1,30 @@
+package com.wl2c.elswhere.domain.product.model.entity
+
+import com.wl2c.elswhere.domain.product.model.UnderlyingAssetType
+import com.wl2c.elswhere.global.base.BaseEntity
+import jakarta.persistence.*
+
+@Entity
+class TickerSymbol(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "ticker_symbol_id")
+    val id: Long? = null,
+
+    @Column(nullable = false)
+    var tickerSymbol: String,
+
+    @Column(nullable = false)
+    var equityName: String,
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    var underlyingAssetType: UnderlyingAssetType,
+
+    ): BaseEntity() {
+
+    @OneToMany(mappedBy = "tickerSymbol", cascade = [CascadeType.ALL], orphanRemoval = true)
+    val productTickerSymbols: MutableList<ProductTickerSymbol> = mutableListOf()
+
+}


### PR DESCRIPTION
## Issue 번호


## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 리펙토링
- [ ] 버그 수정
- [ ] 테스트 코드 작성
- [x] 코드 스타일 업데이트
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트


## 작업 사항
### 자바 필드 -> 코틀린 프로퍼티
- id와 같이 생성 후 변경되지 않는 값은 `val(immutable)`로, 다른 필드처럼 변경될 수 있는 값은 `var(mutable)`로 선언
### Lombok 대체
- 기존 Java 코드
    ```Java
    @Entity
    @Getter
    @NoArgsConstructor(access = AccessLevel.PROTECTED)
    public class Product extends BaseEntity {
    
        @Id
        @GeneratedValue(strategy = GenerationType.IDENTITY)
        @Column(name = "product_id")
        private Long id;
    
        @NotNull
        private String issuer;
        
        // ...
  
        @Builder
        private Product (
            // ...
        ) {
            // ...
        }
  }
    ```
  - Getter 어노테이션: 코틀린의 프로퍼티는 기본적으로 getter를 내장하므로 제거
  - Builder 어노테이션: 코틀린의 Named Arguments 와 Default Arguments 을 사용하면 빌더 패턴을 대체가능 하므로 제거
 ### Null 안전성 (Null Safety)
- Java 코드의 NotNull과 NonNull은 코틀린의 Non-nullable 타입(예: String)으로 변환
- JPA가 DB 스키마를 생성할 때를 대비해 Column(nullable = false) 어노테이션을 명시적으로 추가
