### PR TITLE
refactor: 상품 리포지토리 마이그레이션 및 쿼리 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 HELP.md
 .gradle
+.kotlin
 build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
 	kotlin("jvm") version "1.9.25"
 	kotlin("plugin.spring") version "1.9.25"
 	kotlin("plugin.jpa") version "1.9.25"
+	kotlin("kapt") version "2.1.0"
 	id("org.springframework.boot") version "3.4.8"
 	id("io.spring.dependency-management") version "1.1.7"
 	id("org.jetbrains.kotlinx.kover") version "0.9.1"
@@ -41,6 +42,10 @@ dependencies {
 
 	// mysql
 	runtimeOnly("com.mysql:mysql-connector-j")
+
+	// Querydsl
+	implementation("com.querydsl:querydsl-jpa:5.0.0:jakarta")
+	kapt("com.querydsl:querydsl-apt:5.0.0:jakarta")
 
 	// h2
 	testRuntimeOnly("com.h2database:h2")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,6 +57,11 @@ dependencies {
 	// devtools
 	developmentOnly("org.springframework.boot:spring-boot-devtools")
 
+	// swagger
+	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0")
+	annotationProcessor("com.github.therapi:therapi-runtime-javadoc-scribe:0.15.0")
+	implementation("com.github.therapi:therapi-runtime-javadoc:0.15.0")
+
 	// test
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")

--- a/src/main/kotlin/com/wl2c/elswhere/domain/product/model/dto/request/RequestProductSearchDto.kt
+++ b/src/main/kotlin/com/wl2c/elswhere/domain/product/model/dto/request/RequestProductSearchDto.kt
@@ -1,0 +1,52 @@
+package com.wl2c.elswhere.domain.product.model.dto.request
+
+import com.wl2c.elswhere.domain.product.model.ProductType
+import com.wl2c.elswhere.domain.product.model.UnderlyingAssetType
+import io.swagger.v3.oas.annotations.media.Schema
+import java.math.BigDecimal
+import java.time.LocalDate
+
+data class RequestProductSearchDto(
+
+    @Schema(description = "상품 명", example = "oo투자증권 1234회")
+    val productName: String? = null,
+
+    @Schema(description = "기초자산 명", example = "['S&P500', 'Tesla']")
+    val equityNames: List<String>? = null,
+
+    @Schema(description = "기초자산 수", example = "3")
+    val equityCount: Int? = null,
+
+    @Schema(description = "발행 회사", example = "oo투자증권")
+    val issuer: String? = null,
+
+    @Schema(description = "최대 KI(낙인배리어)", example = "45, 낙인 값이 없을 시 null")
+    val maxKnockIn: Int? = null,
+
+    @Schema(description = "최소 수익률(연, %)", example = "10.2")
+    val minYieldIfConditionsMet: BigDecimal? = null,
+
+    @Schema(description = "1차 상환 배리어", example = "90")
+    val initialRedemptionBarrier: Int? = null,
+
+    @Schema(description = "만기 상환 배리어", example = "65")
+    val maturityRedemptionBarrier: Int? = null,
+
+    @Schema(description = "상품 가입 기간", example = "3")
+    val subscriptionPeriod: Int? = null,
+
+    @Schema(description = "상환일 간격", example = "6")
+    val redemptionInterval: Int? = null,
+
+    @Schema(description = "기초자산 유형", example = "INDEX")
+    val equityType: UnderlyingAssetType? = null,
+
+    @Schema(description = "상품 유형", example = "STEP_DOWN")
+    val type: ProductType? = null,
+
+    @Schema(description = "청약 시작일", example = "2024-06-14")
+    val subscriptionStartDate: LocalDate? = null,
+
+    @Schema(description = "청약 마감일", example = "2024-06-21")
+    val subscriptionEndDate: LocalDate? = null
+)

--- a/src/main/kotlin/com/wl2c/elswhere/domain/product/model/entity/Product.kt
+++ b/src/main/kotlin/com/wl2c/elswhere/domain/product/model/entity/Product.kt
@@ -15,7 +15,7 @@ import java.math.BigDecimal
 import java.time.LocalDate
 
 @Entity
-class Product @Builder private constructor(
+class Product(
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/kotlin/com/wl2c/elswhere/domain/product/repository/EarlyRepaymentEvaluationDatesRepository.kt
+++ b/src/main/kotlin/com/wl2c/elswhere/domain/product/repository/EarlyRepaymentEvaluationDatesRepository.kt
@@ -1,0 +1,30 @@
+package com.wl2c.elswhere.domain.product.repository
+
+import com.wl2c.elswhere.domain.product.model.entity.EarlyRepaymentEvaluationDates
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import java.time.LocalDate
+
+interface EarlyRepaymentEvaluationDatesRepository: JpaRepository<EarlyRepaymentEvaluationDates, Long> {
+
+    @Query("select count(e) + 1 from EarlyRepaymentEvaluationDates e " +
+            "where e.product.id = :productId " +
+            "and e.earlyRepaymentEvaluationDate < :targetDate ")
+    fun findNextEarlyRepaymentEvaluationDateOrder(@Param("productId") productId: Long,
+                                                  @Param("targetDate") targetDate: LocalDate): Int
+
+    @Query("select e.earlyRepaymentEvaluationDate from EarlyRepaymentEvaluationDates e " +
+            "where e.product.productState = 'ACTIVE' " +
+            "and e.product.id = :productId " +
+            "and e.earlyRepaymentEvaluationDate > CURRENT_DATE " +
+            "order by e.earlyRepaymentEvaluationDate asc " +
+            "LIMIT 1 ")
+    fun findNextEarlyRepaymentEvaluationDate(@Param("productId") productId: Long): LocalDate?
+
+    @Query("select e from EarlyRepaymentEvaluationDates e " +
+            "where e.product.productState = 'ACTIVE' " +
+            "and e.product.id = :productId ")
+    fun findAllEarlyRepaymentEvaluationDate(@Param("productId") productId: Long): List<EarlyRepaymentEvaluationDates>
+
+}

--- a/src/main/kotlin/com/wl2c/elswhere/domain/product/repository/EarlyRepaymentEvaluationDatesRepository.kt
+++ b/src/main/kotlin/com/wl2c/elswhere/domain/product/repository/EarlyRepaymentEvaluationDatesRepository.kt
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import java.time.LocalDate
 
-interface EarlyRepaymentEvaluationDatesRepository: JpaRepository<EarlyRepaymentEvaluationDates, Long> {
+interface EarlyRepaymentEvaluationDatesRepository : JpaRepository<EarlyRepaymentEvaluationDates, Long> {
 
     @Query("select count(e) + 1 from EarlyRepaymentEvaluationDates e " +
             "where e.product.id = :productId " +

--- a/src/main/kotlin/com/wl2c/elswhere/domain/product/repository/IssuerRepository.kt
+++ b/src/main/kotlin/com/wl2c/elswhere/domain/product/repository/IssuerRepository.kt
@@ -1,0 +1,12 @@
+package com.wl2c.elswhere.domain.product.repository
+
+import com.wl2c.elswhere.domain.product.model.entity.Issuer
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+
+interface IssuerRepository: JpaRepository<Issuer, Long> {
+
+    @Query("select i from Issuer i " +
+            "where i.issuerState = 'ACTIVE' ")
+    fun findAllByIssuerState(): List<Issuer>
+}

--- a/src/main/kotlin/com/wl2c/elswhere/domain/product/repository/IssuerRepository.kt
+++ b/src/main/kotlin/com/wl2c/elswhere/domain/product/repository/IssuerRepository.kt
@@ -4,7 +4,7 @@ import com.wl2c.elswhere.domain.product.model.entity.Issuer
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 
-interface IssuerRepository: JpaRepository<Issuer, Long> {
+interface IssuerRepository : JpaRepository<Issuer, Long> {
 
     @Query("select i from Issuer i " +
             "where i.issuerState = 'ACTIVE' ")

--- a/src/main/kotlin/com/wl2c/elswhere/domain/product/repository/ProductEquityVolatilityRepository.kt
+++ b/src/main/kotlin/com/wl2c/elswhere/domain/product/repository/ProductEquityVolatilityRepository.kt
@@ -1,0 +1,13 @@
+package com.wl2c.elswhere.domain.product.repository
+
+import com.wl2c.elswhere.domain.product.model.entity.ProductEquityVolatility
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+
+interface ProductEquityVolatilityRepository: JpaRepository<ProductEquityVolatility, Long> {
+
+    @Query("select p from ProductEquityVolatility p " +
+            "where p.id in :productTickerSymbolIdList ")
+    fun findAllByProductTickerSymbol(@Param("productTickerSymbolIdList") productTickerSymbolIdList: List<Long>): List<ProductEquityVolatility>
+}

--- a/src/main/kotlin/com/wl2c/elswhere/domain/product/repository/ProductEquityVolatilityRepository.kt
+++ b/src/main/kotlin/com/wl2c/elswhere/domain/product/repository/ProductEquityVolatilityRepository.kt
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 
-interface ProductEquityVolatilityRepository: JpaRepository<ProductEquityVolatility, Long> {
+interface ProductEquityVolatilityRepository : JpaRepository<ProductEquityVolatility, Long> {
 
     @Query("select p from ProductEquityVolatility p " +
             "where p.id in :productTickerSymbolIdList ")

--- a/src/main/kotlin/com/wl2c/elswhere/domain/product/repository/ProductRepository.kt
+++ b/src/main/kotlin/com/wl2c/elswhere/domain/product/repository/ProductRepository.kt
@@ -1,0 +1,54 @@
+package com.wl2c.elswhere.domain.product.repository
+
+import com.wl2c.elswhere.domain.product.model.entity.Product
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+
+interface ProductRepository: JpaRepository<Product, Long> {
+
+    @Query("select p from Product p " +
+            "where p.productState = 'ACTIVE' and p.id in :productIdList ")
+    fun listByIds(@Param("productIdList") productIdList: List<Long>): List<Product>
+
+    @Query("select p from Product p " +
+            "where p.productState = 'ACTIVE' and p.subscriptionEndDate >= CURRENT_DATE " +
+            "order by case when :sortType = 'knock-in' and p.knockIn is null then 1 else 0 end ")
+    fun listByOnSale(@Param("sortType") sortType: String, pageable: Pageable): Page<Product>
+
+    @Query("select p from Product p " +
+            "where p.productState = 'ACTIVE' and p.subscriptionEndDate < CURRENT_DATE " +
+            "order by case when :sortType = 'knock-in' and p.knockIn is null then 1 else 0 end ")
+    fun listByEndSale(@Param("sortType") sortType: String, pageable: Pageable): Page<Product>
+
+    @Query("select p from Product p " +
+            "where p.productState = 'ACTIVE' and p.subscriptionEndDate >= CURRENT_DATE " +
+            "and p.type = 'STEP_DOWN' ")
+    fun listByOnSaleAndStepDown(): List<Product>
+
+    @Query("select p from Product p where p.productState = 'ACTIVE' and function('date', p.createdAt) = CURRENT_DATE ")
+    fun listByCreatedAtToday(): List<Product>
+
+    @Query("select p from Product p " +
+            "where p.productState = 'ACTIVE' " +
+            "and p.id = :id " +
+            "and p.subscriptionEndDate >= CURRENT_DATE")
+    fun isItProductOnSale(@Param("id") id: Long): Product?
+
+    @Query("select p from Product p where p.productState = 'ACTIVE' and p.id = :id ")
+    fun findOne(@Param("id") id: Long): Product?
+
+    @Query("select p from Product p " +
+            "where p.productState = 'ACTIVE' " +
+            "and p.subscriptionEndDate >= CURRENT_DATE " +
+            "and p.id <> :targetId " +
+            "and p.equityCount = :targetEquityCount " +
+            "and (select count(subpts.id) from ProductTickerSymbol subpts " +
+            "       where subpts.product.id = p.id " +
+            "       and subpts.tickerSymbol.tickerSymbol in :targetEquityTickerSymbols) = :targetEquityCount ")
+    fun findComparisonResults(@Param("targetId") targetId: Long,
+                              @Param("targetEquityCount") targetEquityCount: Int,
+                              @Param("targetEquityTickerSymbols") targetEquityTickerSymbols: List<String>): List<Product>
+}

--- a/src/main/kotlin/com/wl2c/elswhere/domain/product/repository/ProductRepository.kt
+++ b/src/main/kotlin/com/wl2c/elswhere/domain/product/repository/ProductRepository.kt
@@ -41,13 +41,15 @@ interface ProductRepository: JpaRepository<Product, Long> {
     fun findOne(@Param("id") id: Long): Product?
 
     @Query("select p from Product p " +
+            "join p.productTickerSymbols subpts on subpts.product.id = p.id " +
+            "join subpts.tickerSymbol ts on ts.id = subpts.tickerSymbol.id " +
             "where p.productState = 'ACTIVE' " +
             "and p.subscriptionEndDate >= CURRENT_DATE " +
             "and p.id <> :targetId " +
             "and p.equityCount = :targetEquityCount " +
-            "and (select count(subpts.id) from ProductTickerSymbol subpts " +
-            "       where subpts.product.id = p.id " +
-            "       and subpts.tickerSymbol.tickerSymbol in :targetEquityTickerSymbols) = :targetEquityCount ")
+            "and ts.tickerSymbol IN :targetEquityTickerSymbols " +
+            "group by p.id " +
+            "having count(subpts.id) = :targetEquityCount ")
     fun findComparisonResults(@Param("targetId") targetId: Long,
                               @Param("targetEquityCount") targetEquityCount: Int,
                               @Param("targetEquityTickerSymbols") targetEquityTickerSymbols: List<String>): List<Product>

--- a/src/main/kotlin/com/wl2c/elswhere/domain/product/repository/ProductRepository.kt
+++ b/src/main/kotlin/com/wl2c/elswhere/domain/product/repository/ProductRepository.kt
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 
-interface ProductRepository: JpaRepository<Product, Long> {
+interface ProductRepository : JpaRepository<Product, Long> {
 
     @Query("select p from Product p " +
             "where p.productState = 'ACTIVE' and p.id in :productIdList ")

--- a/src/main/kotlin/com/wl2c/elswhere/domain/product/repository/ProductSearchRepository.kt
+++ b/src/main/kotlin/com/wl2c/elswhere/domain/product/repository/ProductSearchRepository.kt
@@ -1,0 +1,237 @@
+package com.wl2c.elswhere.domain.product.repository
+
+import com.querydsl.core.Tuple
+import com.querydsl.core.types.dsl.BooleanExpression
+import com.querydsl.core.types.dsl.Expressions
+import com.querydsl.core.types.dsl.NumberTemplate
+import com.querydsl.core.types.dsl.StringTemplate
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.wl2c.elswhere.domain.product.model.ProductState
+import com.wl2c.elswhere.domain.product.model.ProductType
+import com.wl2c.elswhere.domain.product.model.UnderlyingAssetType
+import com.wl2c.elswhere.domain.product.model.dto.request.RequestProductSearchDto
+import com.wl2c.elswhere.domain.product.model.entity.Product
+import com.wl2c.elswhere.domain.product.model.entity.QEarlyRepaymentEvaluationDates.earlyRepaymentEvaluationDates
+import com.wl2c.elswhere.domain.product.model.entity.QProduct.product
+import com.wl2c.elswhere.domain.product.model.entity.QProductTickerSymbol.productTickerSymbol
+import com.wl2c.elswhere.domain.product.model.entity.QTickerSymbol.tickerSymbol1
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Repository
+import org.springframework.util.StringUtils.hasText
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.Period
+
+@Repository
+class ProductSearchRepository(
+    private val queryFactory: JPAQueryFactory
+) {
+
+    fun searchByIssueNumber(issueNumber: Int?): List<Product> =
+        queryFactory.selectFrom(product)
+            .where(
+                issueNumberEq(issueNumber),
+                product.productState.eq(ProductState.ACTIVE)
+            )
+            .orderBy(product.id.desc())
+            .fetch()
+
+    fun search(requestDto: RequestProductSearchDto, pageable: Pageable): List<Product> =
+        queryFactory.selectFrom(product)
+            .where(
+                productNameContain(requestDto.productName),
+                equityNamesIn(requestDto.equityNames),
+                equityCountEq(requestDto.equityCount),
+                issuerEq(requestDto.issuer),
+                knockInLoe(requestDto.maxKnockIn),
+                yieldIfConditionsMetGoe(requestDto.minYieldIfConditionsMet),
+                initialRedemptionBarrierEq(requestDto.initialRedemptionBarrier),
+                maturityRedemptionBarrierEq(requestDto.maturityRedemptionBarrier),
+                subscriptionPeriodEq(requestDto.subscriptionPeriod),
+                redemptionIntervalEq(requestDto.redemptionInterval),
+                equityTypeEq(requestDto.equityType),
+                typeEq(requestDto.type),
+                periodBetween(requestDto.subscriptionStartDate, requestDto.subscriptionEndDate),
+                product.productState.eq(ProductState.ACTIVE)
+            )
+            .orderBy(product.id.desc())
+            .offset(pageable.offset)
+            .limit(pageable.pageSize.toLong())
+            .fetch()
+
+    // 상품 명 (일부 가능)
+    private fun productNameContain(name: String?): BooleanExpression? =
+        name?.let { product.name.contains(it) }
+
+    // 기초자산 명
+    private fun equityNamesIn(equityNames: List<String>?): BooleanExpression? {
+        if (equityNames != null) {
+            val tickerSymbolList = equityNames.mapNotNull { equityName ->
+                queryFactory
+                    .select(tickerSymbol1.tickerSymbol)
+                    .from(tickerSymbol1)
+                    .where(tickerSymbol1.equityName.eq(equityName))
+                    .fetchOne()
+            }
+
+            val result = queryFactory
+                .select(productTickerSymbol.product.id)
+                .from(productTickerSymbol)
+                .where(productTickerSymbol.tickerSymbol.tickerSymbol.`in`(tickerSymbolList))
+                .groupBy(productTickerSymbol.product.id)
+                .having(productTickerSymbol.tickerSymbol.tickerSymbol.count().eq(tickerSymbolList.size.toLong()))
+                .fetch()
+
+            return product.id.`in`(result)
+        }
+        return null
+    }
+
+    // 기초자산 개수
+    private fun equityCountEq(equityCount: Int?): BooleanExpression? =
+        equityCount?.let { product.equityCount.eq(it) }
+
+    // 발행회사
+    private fun issuerEq(issuer: String?): BooleanExpression? =
+        if (hasText(issuer)) product.issuer.eq(issuer) else null
+
+    // 최대 KI
+    private fun knockInLoe(maxKnockIn: Int?): BooleanExpression? =
+        maxKnockIn?.let { product.knockIn.loe(it) }
+
+    // 최소 수익률
+    private fun yieldIfConditionsMetGoe(minYieldIfConditionsMet: BigDecimal?): BooleanExpression? =
+        minYieldIfConditionsMet?.let { product.yieldIfConditionsMet.goe(it) }
+
+    // 1차 상환 배리어
+    private fun initialRedemptionBarrierEq(initialRedemptionBarrier: Int?): BooleanExpression? {
+        if (initialRedemptionBarrier != null) {
+            val firstNumberString: StringTemplate = Expressions.stringTemplate(
+                "REGEXP_SUBSTR({0}, '^[0-9]+')",
+                product.productInfo
+            )
+            val firstNumber: NumberTemplate<Int> = Expressions.numberTemplate(
+                Int::class.java,
+                "CAST({0} AS DOUBLE)",
+                firstNumberString
+            )
+            return firstNumber.eq(initialRedemptionBarrier)
+        }
+        return null
+    }
+
+    // 만기 상환 배리어
+    private fun maturityRedemptionBarrierEq(maturityRedemptionBarrier: Int?): BooleanExpression? {
+        if (maturityRedemptionBarrier != null) {
+            val firstNumberString: StringTemplate = Expressions.stringTemplate(
+                "SUBSTRING_INDEX(SUBSTRING_INDEX({0}, '-', -1), '(', 1)",
+                product.productInfo
+            )
+            val firstNumber: NumberTemplate<Int> = Expressions.numberTemplate(
+                Int::class.java,
+                "CAST({0} AS DOUBLE)",
+                firstNumberString
+            )
+            return firstNumber.eq(maturityRedemptionBarrier)
+        }
+        return null
+    }
+
+    // 상품 가입 기간
+    private fun subscriptionPeriodEq(subscriptionPeriod: Int?): BooleanExpression? {
+        if (subscriptionPeriod != null) {
+            val monthsDiff: NumberTemplate<Int> = Expressions.numberTemplate(
+                Int::class.java,
+                "PERIOD_DIFF(DATE_FORMAT({1}, '%Y%m'), DATE_FORMAT({0}, '%Y%m'))",
+                product.issuedDate,
+                product.maturityDate
+            )
+            val monthsAsDouble: NumberTemplate<Double> = Expressions.numberTemplate(
+                Double::class.java,
+                "CAST({0} AS DOUBLE)",
+                monthsDiff
+            )
+            val yearsDiff: NumberTemplate<Double> = Expressions.numberTemplate(
+                Double::class.java,
+                "{0} / 12",
+                monthsAsDouble
+            )
+            val roundedYears: NumberTemplate<Double> = Expressions.numberTemplate(
+                Double::class.java,
+                "CEIL({0})",
+                yearsDiff
+            )
+            return roundedYears.eq(subscriptionPeriod.toDouble())
+        }
+        return null
+    }
+
+    // 상환일 간격
+    private fun redemptionIntervalEq(redemptionInterval: Int?): BooleanExpression? {
+        if (redemptionInterval != null) {
+            val results: List<Tuple> = queryFactory
+                .select(earlyRepaymentEvaluationDates.product.id, earlyRepaymentEvaluationDates.earlyRepaymentEvaluationDate)
+                .from(earlyRepaymentEvaluationDates)
+                .groupBy(earlyRepaymentEvaluationDates.product.id, earlyRepaymentEvaluationDates.earlyRepaymentEvaluationDate)
+                .orderBy(earlyRepaymentEvaluationDates.product.id.asc(), earlyRepaymentEvaluationDates.earlyRepaymentEvaluationDate.asc())
+                .fetch()
+
+            val productDatesMap = mutableMapOf<Long, MutableList<LocalDate>>()
+            val matchingProductIds = mutableListOf<Long>()
+
+            for (tuple in results) {
+                val productId = tuple.get(0, Long::class.java)
+                val date = tuple.get(1, LocalDate::class.java)
+
+                if (productId != null && date != null) {
+                    if (productDatesMap.containsKey(productId) && productDatesMap[productId]!!.size == 2) {
+                        continue
+                    }
+                    productDatesMap.computeIfAbsent(productId) { mutableListOf() }.add(date)
+                }
+            }
+
+            for ((productId, dates) in productDatesMap) {
+                if (dates.size == 2) {
+                    val firstDate = dates[0]
+                    val secondDate = dates[1]
+                    val period = Period.between(firstDate, secondDate)
+                    var monthsDifference = period.years * 12 + period.months
+                    if (period.days >= 20) {
+                        monthsDifference += 1
+                    }
+                    if (monthsDifference == redemptionInterval) {
+                        matchingProductIds.add(productId)
+                    }
+                }
+            }
+            return product.id.`in`(matchingProductIds)
+        }
+        return null
+    }
+
+    // 기초자산 유형
+    private fun equityTypeEq(type: UnderlyingAssetType?): BooleanExpression? =
+        type?.let { product.underlyingAssetType.eq(it) }
+
+    // 상품 유형
+    private fun typeEq(type: ProductType?): BooleanExpression? =
+        type?.let { product.type.eq(it) }
+
+    // 청약 시작일 & 청약 마감일
+    private fun periodBetween(subscriptionStartDate: LocalDate?, subscriptionEndDate: LocalDate?): BooleanExpression? =
+        when {
+            subscriptionStartDate != null && subscriptionEndDate != null ->
+                product.subscriptionStartDate.goe(subscriptionStartDate)
+                    .and(product.subscriptionEndDate.loe(subscriptionEndDate))
+            subscriptionStartDate != null ->
+                product.subscriptionStartDate.goe(subscriptionStartDate)
+            subscriptionEndDate != null ->
+                product.subscriptionEndDate.loe(subscriptionEndDate)
+            else -> null
+        }
+
+    // 회차 번호
+    private fun issueNumberEq(issueNumber: Int?): BooleanExpression? =
+        issueNumber?.let { product.issueNumber.eq(it) }
+}

--- a/src/main/kotlin/com/wl2c/elswhere/domain/product/repository/ProductTickerSymbolRepository.kt
+++ b/src/main/kotlin/com/wl2c/elswhere/domain/product/repository/ProductTickerSymbolRepository.kt
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 
-interface ProductTickerSymbolRepository: JpaRepository<ProductTickerSymbol, Long> {
+interface ProductTickerSymbolRepository : JpaRepository<ProductTickerSymbol, Long> {
 
     @Query("select p from ProductTickerSymbol p " +
             "where p.product.id = :productId ")

--- a/src/main/kotlin/com/wl2c/elswhere/domain/product/repository/ProductTickerSymbolRepository.kt
+++ b/src/main/kotlin/com/wl2c/elswhere/domain/product/repository/ProductTickerSymbolRepository.kt
@@ -2,6 +2,12 @@ package com.wl2c.elswhere.domain.product.repository
 
 import com.wl2c.elswhere.domain.product.model.entity.ProductTickerSymbol
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 
 interface ProductTickerSymbolRepository: JpaRepository<ProductTickerSymbol, Long> {
+
+    @Query("select p from ProductTickerSymbol p " +
+            "where p.product.id = :productId ")
+    fun findAllByProductId(@Param("productId") productId: Long): List<ProductTickerSymbol>
 }

--- a/src/main/kotlin/com/wl2c/elswhere/domain/product/repository/ProductTickerSymbolRepository.kt
+++ b/src/main/kotlin/com/wl2c/elswhere/domain/product/repository/ProductTickerSymbolRepository.kt
@@ -1,0 +1,7 @@
+package com.wl2c.elswhere.domain.product.repository
+
+import com.wl2c.elswhere.domain.product.model.entity.ProductTickerSymbol
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ProductTickerSymbolRepository: JpaRepository<ProductTickerSymbol, Long> {
+}

--- a/src/main/kotlin/com/wl2c/elswhere/domain/product/repository/TickerSymbolRepository.kt
+++ b/src/main/kotlin/com/wl2c/elswhere/domain/product/repository/TickerSymbolRepository.kt
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 
-interface TickerSymbolRepository: JpaRepository<TickerSymbol, Long> {
+interface TickerSymbolRepository : JpaRepository<TickerSymbol, Long> {
     @Query("select ts from TickerSymbol ts " +
             "inner join ProductTickerSymbol pts " +
             "on ts.id = pts.tickerSymbol.id " +

--- a/src/main/kotlin/com/wl2c/elswhere/domain/product/repository/TickerSymbolRepository.kt
+++ b/src/main/kotlin/com/wl2c/elswhere/domain/product/repository/TickerSymbolRepository.kt
@@ -1,0 +1,7 @@
+package com.wl2c.elswhere.domain.product.repository
+
+import com.wl2c.elswhere.domain.product.model.entity.TickerSymbol
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface TickerSymbolRepository: JpaRepository<TickerSymbol, Long> {
+}

--- a/src/main/kotlin/com/wl2c/elswhere/domain/product/repository/TickerSymbolRepository.kt
+++ b/src/main/kotlin/com/wl2c/elswhere/domain/product/repository/TickerSymbolRepository.kt
@@ -2,6 +2,17 @@ package com.wl2c.elswhere.domain.product.repository
 
 import com.wl2c.elswhere.domain.product.model.entity.TickerSymbol
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 
 interface TickerSymbolRepository: JpaRepository<TickerSymbol, Long> {
+    @Query("select ts from TickerSymbol ts " +
+            "inner join ProductTickerSymbol pts " +
+            "on ts.id = pts.tickerSymbol.id " +
+            "where pts.product.id = :productId and pts.product.productState = 'ACTIVE' ")
+    fun findTickerSymbolList(@Param("productId") productId: Long): List<TickerSymbol>
+
+    @Query("select ts from TickerSymbol ts " +
+            "where ts.tickerSymbol <> 'NEED_TO_CHECK' ")
+    override fun findAll(): List<TickerSymbol>
 }

--- a/src/main/kotlin/com/wl2c/elswhere/global/config/QuerydslConfig.kt
+++ b/src/main/kotlin/com/wl2c/elswhere/global/config/QuerydslConfig.kt
@@ -1,0 +1,17 @@
+package com.wl2c.elswhere.global.config
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import jakarta.persistence.EntityManager
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class QuerydslConfig(
+    private val em: EntityManager
+) {
+
+    @Bean
+    fun querydsl(): JPAQueryFactory {
+        return JPAQueryFactory(em)
+    }
+}

--- a/src/main/kotlin/com/wl2c/elswhere/global/config/swagger/SpringDocJavadocProvider.kt
+++ b/src/main/kotlin/com/wl2c/elswhere/global/config/swagger/SpringDocJavadocProvider.kt
@@ -1,0 +1,81 @@
+package com.wl2c.elswhere.global.config.swagger
+
+import com.github.therapi.runtimejavadoc.*
+import org.apache.commons.lang3.StringUtils
+import org.springdoc.core.providers.JavadocProvider
+import org.springframework.stereotype.Component
+import java.lang.reflect.Field
+import java.lang.reflect.Method
+
+@Component
+class SpringDocJavadocProvider : JavadocProvider {
+
+    private val formatter = CommentFormatter()
+
+    override fun getClassJavadoc(cl: Class<*>): String {
+        val classJavadoc = RuntimeJavadoc.getJavadoc(cl)
+        return formatter.format(classJavadoc.comment)
+    }
+
+    override fun getRecordClassParamJavadoc(cl: Class<*>): Map<String, String>? {
+        return null
+    }
+
+    override fun getMethodJavadocDescription(method: Method): String {
+        val methodJavadoc = RuntimeJavadoc.getJavadoc(method)
+        return formatter.format(methodJavadoc.comment)
+    }
+
+    override fun getMethodJavadocReturn(method: Method): String {
+        val methodJavadoc = RuntimeJavadoc.getJavadoc(method)
+        return formatter.format(methodJavadoc.returns)
+    }
+
+    override fun getMethodJavadocThrows(method: Method): Map<String, String> {
+        return RuntimeJavadoc.getJavadoc(method)
+            .throws
+            .associate { it.name to formatter.format(it.comment) }
+    }
+
+    override fun getParamJavadoc(method: Method, name: String): String? {
+        val methodJavadoc = RuntimeJavadoc.getJavadoc(method)
+        return methodJavadoc.params
+            .firstOrNull { it.name == name }
+            ?.let { formatter.format(it.comment) }
+    }
+
+    override fun getFieldJavadoc(field: Field): String {
+        val fieldJavadoc = RuntimeJavadoc.getJavadoc(field)
+        return formatter.format(fieldJavadoc.comment)
+    }
+
+    override fun getFirstSentence(text: String): String {
+        if (StringUtils.isEmpty(text)) return text
+
+        val pOpenIndex = text.indexOf("<p>")
+        val pCloseIndex = text.indexOf("</p>")
+        val newLineIndex = text.indexOf("\n")
+
+        if (pOpenIndex != -1) {
+            if (pOpenIndex == 0 && pCloseIndex != -1) {
+                if (newLineIndex != -1) {
+                    return text.substring(3, minOf(pCloseIndex, newLineIndex))
+                }
+                return text.substring(3, pCloseIndex)
+            }
+            if (newLineIndex != -1) {
+                return text.substring(0, minOf(pOpenIndex, newLineIndex))
+            }
+            return text.substring(0, pOpenIndex)
+        }
+
+        if (newLineIndex != -1 &&
+            text.length != newLineIndex + 1 &&
+            Character.isWhitespace(text[newLineIndex + 1])
+        ) {
+            return text.substring(0, newLineIndex + 1)
+        }
+
+        return text
+    }
+}

--- a/src/main/kotlin/com/wl2c/elswhere/global/config/swagger/SwaggerConfig.kt
+++ b/src/main/kotlin/com/wl2c/elswhere/global/config/swagger/SwaggerConfig.kt
@@ -1,0 +1,43 @@
+package com.wl2c.elswhere.global.config.swagger
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition
+import io.swagger.v3.oas.annotations.info.Info
+import io.swagger.v3.oas.models.Components
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.security.SecurityRequirement
+import io.swagger.v3.oas.models.security.SecurityScheme
+import io.swagger.v3.oas.models.servers.Server
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@OpenAPIDefinition(
+    info = Info(
+        title = "API Document",
+        description = "ELSwhere API 명세서",
+        version = "v1.0.0"
+    )
+)
+class SwaggerConfig(
+    @Value("\${server.url.development}")
+    private val developmentServerUrl: String,
+
+    @Value("\${server.url.local}")
+    private val localServerUrl: String
+) {
+    @Bean
+    fun openAPI(): OpenAPI {
+        val securityScheme = SecurityScheme()
+            .type(SecurityScheme.Type.HTTP).scheme("bearer").bearerFormat("JWT")
+            .`in`(SecurityScheme.In.HEADER).name("Authorization")
+
+        val securityRequirement = SecurityRequirement().addList("bearerAuth")
+
+        return OpenAPI()
+            .components(Components().addSecuritySchemes("bearerAuth", securityScheme))
+            .security(listOf(securityRequirement))
+            .addServersItem(Server().url(developmentServerUrl).description("개발 서버"))
+            .addServersItem(Server().url(localServerUrl).description("로컬 서버"))
+    }
+}

--- a/src/test/kotlin/com/wl2c/elswhere/domain/product/repository/EarlyRepaymentEvaluationDatesRepositoryTest.kt
+++ b/src/test/kotlin/com/wl2c/elswhere/domain/product/repository/EarlyRepaymentEvaluationDatesRepositoryTest.kt
@@ -1,0 +1,116 @@
+package com.wl2c.elswhere.domain.product.repository
+
+import com.wl2c.elswhere.domain.product.model.ProductState
+import com.wl2c.elswhere.domain.product.model.entity.Product
+import com.wl2c.elswhere.mock.EarlyRepaymentEvaluationDatesMock
+import com.wl2c.elswhere.mock.ProductMock
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import java.time.LocalDate
+
+@DataJpaTest
+class EarlyRepaymentEvaluationDatesRepositoryTest @Autowired constructor(
+    private val productRepository: ProductRepository,
+    private val earlyRepaymentEvaluationDatesRepository: EarlyRepaymentEvaluationDatesRepository
+){
+    private val today: LocalDate = LocalDate.now()
+    private lateinit var product: Product
+
+    @BeforeEach
+    fun setup() {
+        productRepository.deleteAll()
+        earlyRepaymentEvaluationDatesRepository.deleteAll()
+
+        product = ProductMock.create()
+        productRepository.save(product)
+    }
+
+    @Test
+    @DisplayName("특정 날짜 이전의 조기 상환 평가 회차를 기반으로 다음 차수를 잘 계산하는지 확인")
+    fun verifyNextOrder() {
+        // given
+        val dates = listOf(
+            today.minusMonths(6),
+            today,
+            today.plusMonths(6),
+            today.plusMonths(12)
+        )
+        earlyRepaymentEvaluationDatesRepository.saveAll(EarlyRepaymentEvaluationDatesMock.createList(product, dates))
+        val targetDate = today.plusDays(1)
+
+        // when
+        val nextOrder = earlyRepaymentEvaluationDatesRepository.findNextEarlyRepaymentEvaluationDateOrder(product.id!!, targetDate)
+
+        // then
+        assertThat(nextOrder).isNotNull()
+        assertThat(nextOrder).isEqualTo(3)
+    }
+
+    @Test
+    @DisplayName("현재 날짜 이후 가장 빠른 상환 평가일을 정확히 반환한다")
+    fun getEarliestFutureEvaluationDate() {
+        // given
+        val dates = listOf(
+            today.minusMonths(6),
+            today.plusMonths(6),
+            today.plusMonths(12)
+        )
+        earlyRepaymentEvaluationDatesRepository.saveAll(EarlyRepaymentEvaluationDatesMock.createList(product, dates))
+
+        // when
+        val nextDate = earlyRepaymentEvaluationDatesRepository.findNextEarlyRepaymentEvaluationDate(product.id!!)
+
+        // then
+        assertThat(nextDate).isNotNull()
+        assertThat(nextDate).isEqualTo(today.plusMonths(6))
+    }
+
+    @Test
+    @DisplayName("현재 날짜 이후 가장 빠른 상환 평가일이 존재하지 않는 경우 null을 반환한다")
+    fun getNonExistentEarliestFutureEvaluationDate() {
+        // when
+        val nextDate = earlyRepaymentEvaluationDatesRepository.findNextEarlyRepaymentEvaluationDate(product.id!!)
+
+        // then
+        assertThat(nextDate).isNull()
+    }
+
+    @Test
+    @DisplayName("특정 상품 id에 연결된 모든 상환 평가일 목록을 반환한다")
+    fun getAllEvaluationDatesAboutProductId() {
+        // given
+        val dates = listOf(
+            today.minusMonths(6),
+            today,
+            today.plusMonths(6)
+        )
+        earlyRepaymentEvaluationDatesRepository.saveAll(EarlyRepaymentEvaluationDatesMock.createList(product, dates))
+
+        // when
+        val allDates = earlyRepaymentEvaluationDatesRepository.findAllEarlyRepaymentEvaluationDate(product.id!!)
+
+        // then
+        assertThat(allDates).hasSize(3)
+        assertThat(allDates).extracting("earlyRepaymentEvaluationDate").containsExactlyInAnyOrderElementsOf(dates)
+    }
+
+    @Test
+    @DisplayName("상품이 비활성 상태이면 빈 리스트를 반환한다")
+    fun `should return empty list if product is inactive`() {
+        // given
+        val inactiveProduct = productRepository.save(ProductMock.create(productState = ProductState.INACTIVE))
+        val dates = listOf(today.plusMonths(6))
+        earlyRepaymentEvaluationDatesRepository.saveAll(EarlyRepaymentEvaluationDatesMock.createList(inactiveProduct, dates))
+
+        // when
+        val allDates = earlyRepaymentEvaluationDatesRepository.findAllEarlyRepaymentEvaluationDate(inactiveProduct.id!!)
+
+        // then
+        assertThat(allDates).isNotNull
+        assertThat(allDates).isEmpty()
+    }
+}

--- a/src/test/kotlin/com/wl2c/elswhere/domain/product/repository/IssuerRepositoryTest.kt
+++ b/src/test/kotlin/com/wl2c/elswhere/domain/product/repository/IssuerRepositoryTest.kt
@@ -1,0 +1,35 @@
+package com.wl2c.elswhere.domain.product.repository
+
+import com.wl2c.elswhere.domain.product.model.IssuerState
+import com.wl2c.elswhere.domain.product.model.entity.Issuer
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+
+@DataJpaTest
+class IssuerRepositoryTest @Autowired constructor(
+    private val issuerRepository: IssuerRepository
+) {
+
+    @Test
+    @DisplayName("ACTIVE 상태인 모든 발행사 리스트를 잘 가져오는지 확인")
+    fun findAllByIssuerState() {
+        // given
+        val issuer1 = Issuer("A증권", IssuerState.ACTIVE)
+        val issuer2 = Issuer("B증권", IssuerState.INACTIVE)
+        val issuer3 = Issuer("C증권", IssuerState.ACTIVE)
+        issuerRepository.saveAll(listOf(issuer1, issuer2, issuer3))
+
+        // when
+        val result = issuerRepository.findAllByIssuerState()
+
+        // then
+        assertThat(result).isNotNull
+        assertThat(result.size).isEqualTo(2)
+        assertThat(result)
+            .extracting("issuerName")
+            .containsExactlyInAnyOrder("A증권", "C증권")
+    }
+}

--- a/src/test/kotlin/com/wl2c/elswhere/domain/product/repository/ProductEquityVolatilityRepositoryTest.kt
+++ b/src/test/kotlin/com/wl2c/elswhere/domain/product/repository/ProductEquityVolatilityRepositoryTest.kt
@@ -1,0 +1,67 @@
+package com.wl2c.elswhere.domain.product.repository
+
+import com.wl2c.elswhere.domain.product.model.entity.Product
+import com.wl2c.elswhere.domain.product.model.entity.ProductEquityVolatility
+import com.wl2c.elswhere.domain.product.model.entity.ProductTickerSymbol
+import com.wl2c.elswhere.mock.ProductEquityVolatilityMock
+import com.wl2c.elswhere.mock.ProductMock
+import com.wl2c.elswhere.mock.ProductTickerSymbolMock
+import com.wl2c.elswhere.mock.TickerSymbolMock
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import java.math.BigDecimal
+
+@DataJpaTest
+class ProductEquityVolatilityRepositoryTest @Autowired constructor(
+    private val productEquityVolatilityRepository: ProductEquityVolatilityRepository,
+    private val productTickerSymbolRepository: ProductTickerSymbolRepository,
+    private val productRepository: ProductRepository,
+    private val tickerSymbolRepository: TickerSymbolRepository
+) {
+
+    private lateinit var product: Product
+    private lateinit var pts1: ProductTickerSymbol
+    private lateinit var pts2: ProductTickerSymbol
+    private lateinit var volatility1: ProductEquityVolatility
+    private lateinit var volatility2: ProductEquityVolatility
+
+    @BeforeEach
+    fun setup() {
+        productEquityVolatilityRepository.deleteAll()
+        productTickerSymbolRepository.deleteAll()
+        tickerSymbolRepository.deleteAll()
+        productRepository.deleteAll()
+
+        product = productRepository.save(ProductMock.create())
+        val ticker1 = tickerSymbolRepository.save(TickerSymbolMock.create("AAPL", "Apple Inc"))
+        val ticker2 = tickerSymbolRepository.save(TickerSymbolMock.create("MSFT", "Microsoft Corp"))
+
+        pts1 = productTickerSymbolRepository.save(ProductTickerSymbolMock.create(product, ticker1))
+        pts2 = productTickerSymbolRepository.save(ProductTickerSymbolMock.create(product, ticker2))
+
+        volatility1 = productEquityVolatilityRepository.save(ProductEquityVolatilityMock.create(pts1, BigDecimal("0.25")))
+        volatility2 = productEquityVolatilityRepository.save(ProductEquityVolatilityMock.create(pts2, BigDecimal("0.30")))
+    }
+
+    @Test
+    @DisplayName("ProductTickerSymbol id 목록에 해당하는 변동성 정보를 정확히 조회한다")
+    fun getAllMatchingVolatilities() {
+        // given
+        val unrelatedTicker = tickerSymbolRepository.save(TickerSymbolMock.create("TSLA", "Tesla Inc"))
+        val unrelatedPts = productTickerSymbolRepository.save(ProductTickerSymbolMock.create(product, unrelatedTicker))
+        productEquityVolatilityRepository.save(ProductEquityVolatilityMock.create(unrelatedPts, BigDecimal("0.45")))
+        val idsToFind = listOf(pts1.id!!, pts2.id!!)
+
+        // when
+        val foundVolatilities = productEquityVolatilityRepository.findAllByProductTickerSymbol(idsToFind)
+
+        // then
+        assertThat(foundVolatilities).hasSize(2)
+        assertThat(foundVolatilities).extracting("id").containsExactlyInAnyOrder(pts1.id, pts2.id)
+        assertThat(foundVolatilities).extracting("volatility").containsExactlyInAnyOrder(volatility1.volatility, volatility2.volatility)
+    }
+}

--- a/src/test/kotlin/com/wl2c/elswhere/domain/product/repository/ProductRepositoryTest.kt
+++ b/src/test/kotlin/com/wl2c/elswhere/domain/product/repository/ProductRepositoryTest.kt
@@ -1,0 +1,178 @@
+package com.wl2c.elswhere.domain.product.repository
+
+import com.wl2c.elswhere.domain.product.model.MaturityEvaluationDateType
+import com.wl2c.elswhere.domain.product.model.ProductState
+import com.wl2c.elswhere.domain.product.model.ProductType
+import com.wl2c.elswhere.domain.product.model.UnderlyingAssetType
+import com.wl2c.elswhere.domain.product.model.entity.Product
+import com.wl2c.elswhere.mock.ProductMock
+import com.wl2c.elswhere.mock.ProductTickerSymbolMock
+import com.wl2c.elswhere.mock.TickerSymbolMock
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.data.domain.Pageable
+import java.math.BigDecimal
+import java.time.LocalDate
+
+@DataJpaTest
+class ProductRepositoryTest @Autowired constructor(
+    private val productRepository: ProductRepository,
+    private val productTickerSymbolRepository: ProductTickerSymbolRepository,
+    private val tickerSymbolRepository: TickerSymbolRepository
+){
+    private lateinit var product1: Product
+    private lateinit var product2: Product
+
+    @BeforeEach
+    fun setup() {
+        productTickerSymbolRepository.deleteAll()
+        tickerSymbolRepository.deleteAll()
+        productRepository.deleteAll()
+
+        val tickerSymbols = listOf(
+            TickerSymbolMock.create("005930.KS", "삼성전자", UnderlyingAssetType.STOCK),
+            TickerSymbolMock.create("^GSPC", "S&P500", UnderlyingAssetType.INDEX),
+            TickerSymbolMock.create("^KS200", "KOSPI200", UnderlyingAssetType.INDEX),
+            TickerSymbolMock.create("TSLA", "Tesla", UnderlyingAssetType.STOCK),
+            TickerSymbolMock.create("^HSCE", "HSCEI", UnderlyingAssetType.INDEX),
+            TickerSymbolMock.create("NVDA", "NVIDIA", UnderlyingAssetType.STOCK)
+        )
+
+        product1 = ProductMock.create(
+            issuer = "AA증권",
+            name = "1호",
+            equities = "삼성전자 / S&P500 / KOSPI200",
+            equityCount = 3,
+            issuedDate = LocalDate.now().minusDays(1),
+            maturityDate = LocalDate.now().plusYears(3),
+            maturityEvaluationDate = LocalDate.now().plusYears(3).minusDays(5),
+            maturityEvaluationDateType = MaturityEvaluationDateType.SINGLE,
+            yieldIfConditionsMet = BigDecimal("10.423"),
+            subscriptionStartDate = LocalDate.now().minusDays(14),
+            subscriptionEndDate = LocalDate.now().minusDays(1),
+            productInfo = "95-90-85-80-75-50",
+            knockIn = 45,
+            type = ProductType.STEP_DOWN,
+            underlyingAssetType = UnderlyingAssetType.MIX,
+            productState = ProductState.ACTIVE
+        )
+
+        product2 = ProductMock.create(
+            issuer = "BB증권",
+            name = "2호",
+            equities = "Tesla / HSCEI / NVIDIA",
+            equityCount = 3,
+            issuedDate = LocalDate.now().minusDays(1),
+            maturityDate = LocalDate.now().plusYears(3),
+            maturityEvaluationDate = LocalDate.now().plusYears(3).minusDays(3),
+            maturityEvaluationDateType = MaturityEvaluationDateType.SINGLE,
+            yieldIfConditionsMet = BigDecimal("15.34"),
+            subscriptionStartDate = LocalDate.now().minusDays(14),
+            subscriptionEndDate = LocalDate.now(),
+            productInfo = "95-90-85-80-75-50",
+            knockIn = 40,
+            type = ProductType.STEP_DOWN,
+            underlyingAssetType = UnderlyingAssetType.MIX,
+            productState = ProductState.ACTIVE
+        )
+
+        tickerSymbolRepository.saveAll(tickerSymbols);
+        productRepository.save(product1)
+        productRepository.save(product2)
+
+        val productTickerSymbol1 = ProductTickerSymbolMock.createList(product1, listOf(tickerSymbols[0], tickerSymbols[1], tickerSymbols[2]))
+        val productTickerSymbol2 = ProductTickerSymbolMock.createList(product1, listOf(tickerSymbols[3], tickerSymbols[4], tickerSymbols[5]))
+        productTickerSymbolRepository.saveAll(productTickerSymbol1)
+        productTickerSymbolRepository.saveAll(productTickerSymbol2)
+    }
+
+    @Test
+    @DisplayName("상품 id 리스트에 해당하는 상품 리스트를 잘 가져오는지 확인")
+    fun listByIds() {
+        // given & when
+        val list = listOf(product1.id!!, product2.id!!)
+        val productList = productRepository.listByIds(list)
+
+        // then
+        assertThat(productList.size).isEqualTo(2)
+        assertThat(productList[0].issuer).isEqualTo("AA증권")
+        assertThat(productList[1].issuer).isEqualTo("BB증권")
+    }
+
+    @Test
+    @DisplayName("특정 상품 id로 상품을 조회하는지 확인")
+    fun findOne() {
+        // given & when
+        val foundProduct = productRepository.findOne(product1.id!!)
+
+        // then
+        assertThat(foundProduct).isNotNull
+        assertThat(foundProduct?.issuer).isEqualTo("AA증권")
+    }
+
+    @Test
+    @DisplayName("청약 중인 상품인지를 잘 구분하는지 확인")
+    fun findOnSale() {
+        // given & when
+        val result = productRepository.listByOnSale("knock-in", Pageable.unpaged())
+
+        // then
+        assertThat(result.totalElements).isEqualTo(1L)
+        assertThat(result.content.any { it.name == "2호" }).isTrue
+    }
+
+    @Test
+    @DisplayName("청약 종료인 상품인지를 잘 구분하는지 확인")
+    fun findEndSale() {
+        // given & when
+        val result = productRepository.listByEndSale("knock-in", Pageable.unpaged())
+
+        // then
+        assertThat(result.totalElements).isEqualTo(1L)
+        assertThat(result.content.any { it.name == "1호" }).isTrue
+    }
+
+    @Test
+    @DisplayName("상품이 청약 중인지 확인")
+    fun isItProductOnSale() {
+        // given & when
+        val onSaleProduct = productRepository.isItProductOnSale(product2.id!!)
+
+        // then
+        assertThat(onSaleProduct).isNotNull
+        assertThat(onSaleProduct?.name).isEqualTo("2호")
+    }
+
+    @Test
+    @DisplayName("STEP_DOWN 타입 청약 중인 상품을 잘 가져오는지 확인")
+    fun listByOnSaleAndStepDown() {
+        // given & when
+        val stepDownList = productRepository.listByOnSaleAndStepDown()
+
+        // then
+        assertThat(stepDownList).isNotEmpty
+        assertThat(stepDownList.all { it.type == ProductType.STEP_DOWN }).isTrue
+    }
+
+    @Test
+    @DisplayName("비교 결과 상품을 잘 찾아오는지 확인")
+    fun findComparisonResults() {
+        // given
+        val targetEquityTickerSymbols = listOf("005930.KS", "^GSPC", "^KS200")
+
+        // when
+        val comparisonResults = productRepository.findComparisonResults(
+            targetId = 0L,
+            targetEquityCount = 3,
+            targetEquityTickerSymbols = targetEquityTickerSymbols
+        )
+
+        // then
+        assertThat(comparisonResults).isNotNull
+        assertThat(comparisonResults.all { it.id == product1.id }).isTrue
+    }
+}

--- a/src/test/kotlin/com/wl2c/elswhere/domain/product/repository/ProductSearchRepositoryTest.kt
+++ b/src/test/kotlin/com/wl2c/elswhere/domain/product/repository/ProductSearchRepositoryTest.kt
@@ -1,0 +1,296 @@
+package com.wl2c.elswhere.domain.product.repository
+
+import com.wl2c.elswhere.domain.product.model.ProductType
+import com.wl2c.elswhere.domain.product.model.UnderlyingAssetType
+import com.wl2c.elswhere.domain.product.model.dto.request.RequestProductSearchDto
+import com.wl2c.elswhere.domain.product.model.entity.Product
+import com.wl2c.elswhere.global.config.QuerydslConfig
+import com.wl2c.elswhere.mock.EarlyRepaymentEvaluationDatesMock
+import com.wl2c.elswhere.mock.ProductMock
+import com.wl2c.elswhere.mock.ProductTickerSymbolMock
+import com.wl2c.elswhere.mock.TickerSymbolMock
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.context.annotation.Import
+import org.springframework.data.domain.PageRequest
+import java.math.BigDecimal
+import java.time.LocalDate
+
+@DataJpaTest
+@Import(ProductSearchRepository::class, QuerydslConfig::class)
+class ProductSearchRepositoryTest @Autowired constructor(
+    private val earlyRepaymentEvaluationDatesRepository: EarlyRepaymentEvaluationDatesRepository,
+    private val productTickerSymbolRepository: ProductTickerSymbolRepository,
+    private val tickerSymbolRepository: TickerSymbolRepository,
+    private val productRepository: ProductRepository,
+    private val productSearchRepository: ProductSearchRepository
+) {
+    private lateinit var product1: Product
+    private lateinit var product2: Product
+    private lateinit var product3: Product
+
+    private val today = LocalDate.now()
+    private val unpaged = PageRequest.of(0, Int.MAX_VALUE)
+
+    @BeforeEach
+    fun setup() {
+        earlyRepaymentEvaluationDatesRepository.deleteAll()
+        productTickerSymbolRepository.deleteAll()
+        tickerSymbolRepository.deleteAll()
+        productRepository.deleteAll()
+
+        val tickerSymbols = tickerSymbolRepository.saveAll(listOf(
+            TickerSymbolMock.create("005930.KS", "삼성전자", UnderlyingAssetType.STOCK),
+            TickerSymbolMock.create("^GSPC", "S&P500", UnderlyingAssetType.INDEX),
+            TickerSymbolMock.create("^KS200", "KOSPI200", UnderlyingAssetType.INDEX),
+            TickerSymbolMock.create("TSLA", "Tesla", UnderlyingAssetType.STOCK),
+            TickerSymbolMock.create("^HSCE", "HSCEI", UnderlyingAssetType.INDEX),
+            TickerSymbolMock.create("NVDA", "NVIDIA", UnderlyingAssetType.STOCK)
+        ))
+
+        product1 = productRepository.save(
+            ProductMock.create(
+            issuer = "AA증권",
+            name = "AA증권 1호",
+            equities = "삼성전자 / S&P500 / KOSPI200",
+            subscriptionEndDate = today.minusDays(1),
+            knockIn = 45,
+            type = ProductType.STEP_DOWN,
+            underlyingAssetType = UnderlyingAssetType.MIX,
+            yieldIfConditionsMet = BigDecimal("10.423")
+        ))
+
+        product2 = productRepository.save(ProductMock.create(
+            issuer = "BB증권",
+            name = "BB증권 2호",
+            equities = "S&P500 / HSCEI / KOSPI200",
+            subscriptionEndDate = today,
+            knockIn = 40,
+            type = ProductType.STEP_DOWN,
+            underlyingAssetType = UnderlyingAssetType.INDEX,
+            yieldIfConditionsMet = BigDecimal("15.34")
+        ))
+
+        product3 = productRepository.save(ProductMock.create(
+            issuer = "CC증권",
+            name = "CC증권 3호",
+            equities = "Tesla / 삼성전자 / NVIDIA",
+            subscriptionEndDate = today,
+            knockIn = 50,
+            type = ProductType.LIZARD,
+            underlyingAssetType = UnderlyingAssetType.STOCK,
+            yieldIfConditionsMet = BigDecimal("11.234")
+        ))
+
+        productTickerSymbolRepository.saveAll(ProductTickerSymbolMock.createList(product1, listOf(tickerSymbols[0], tickerSymbols[1], tickerSymbols[2])))
+        productTickerSymbolRepository.saveAll(ProductTickerSymbolMock.createList(product2, listOf(tickerSymbols[1], tickerSymbols[4], tickerSymbols[2])))
+        productTickerSymbolRepository.saveAll(ProductTickerSymbolMock.createList(product3, listOf(tickerSymbols[3], tickerSymbols[0], tickerSymbols[5])))
+    }
+
+    @Test
+    @DisplayName("상품 검색 - 원하는 이름을 포함하는 상품을 잘 가져오는지 확인1")
+    fun searchProductName_1() {
+        // given
+        val searchDto = RequestProductSearchDto(productName = "AA")
+
+        // when
+        val result = productSearchRepository.search(searchDto, unpaged)
+
+        // then
+        assertThat(result.size).isEqualTo(1)
+    }
+
+    @Test
+    @DisplayName("상품 검색 - 원하는 이름을 포함하는 상품을 잘 가져오는지 확인2")
+    fun searchProductName_2() {
+        // given
+        val searchDto = RequestProductSearchDto(productName = "증권")
+
+        // when
+        val result = productSearchRepository.search(searchDto, unpaged)
+
+        // then
+        assertThat(result.size).isEqualTo(3)
+    }
+
+    @Test
+    @DisplayName("상품 검색 - 원하는 조건의 발행회사 상품을 잘 가져오는지 확인")
+    fun searchPublisher() {
+        // given
+        val searchDto = RequestProductSearchDto(issuer = "AA증권")
+
+        // when
+        val result = productSearchRepository.search(searchDto, unpaged)
+
+        // then
+        assertThat(result.size).isEqualTo(1)
+    }
+
+    @Test
+    @DisplayName("상품 검색 - 원하는 조건의 기초자산 수를 가진 상품을 잘 가져오는지 확인")
+    fun searchEquityCount() {
+        // given
+        val searchDto = RequestProductSearchDto(equityCount = 3)
+
+        // when
+        val result = productSearchRepository.search(searchDto, unpaged)
+
+        // then
+        assertThat(result.size).isEqualTo(3)
+    }
+
+    @Test
+    @DisplayName("상품 검색 - 설정한 최대 낙인 이하의 상품을 잘 가져오는지 확인")
+    fun searchMaxKnockIn() {
+        // given
+        val searchDto = RequestProductSearchDto(maxKnockIn = 50)
+
+        // when
+        val result = productSearchRepository.search(searchDto, unpaged)
+
+        // then
+        assertThat(result.size).isEqualTo(3)
+    }
+
+    @Test
+    @DisplayName("상품 검색 - 최소 수익률 이상인 상품을 잘 가져오는지 확인")
+    fun searchMinYield() {
+        // given
+        val searchDto = RequestProductSearchDto(minYieldIfConditionsMet = BigDecimal.valueOf(12))
+
+        // when
+        val result = productSearchRepository.search(searchDto, unpaged)
+
+        // then
+        assertThat(result.size).isEqualTo(1)
+        assertThat(result.any { it.name == "BB증권 2호" }).isTrue()
+    }
+
+    @Test
+    @DisplayName("상품 검색 - 설정한 1차 상환 배리어에 해당하는 상품을 잘 가져오는지 확인")
+    fun searchInitialRedemptionBarrier() {
+        // given
+        val searchDto = RequestProductSearchDto(initialRedemptionBarrier = 95)
+
+        // when
+        val result = productSearchRepository.search(searchDto, unpaged)
+
+        // then
+        assertThat(result.size).isEqualTo(3)
+    }
+
+    @Test
+    @DisplayName("상품 검색 - 설정한 상품 종류에 해당하는 상품을 잘 가져오는지 확인")
+    fun searchProductType() {
+        // given
+        val searchDto = RequestProductSearchDto(type = ProductType.STEP_DOWN)
+
+        // when
+        val result = productSearchRepository.search(searchDto, unpaged)
+
+        // then
+        assertThat(result.size).isEqualTo(2)
+    }
+
+    @Test
+    @DisplayName("상품 검색 - 설정한 청약 기간에 속하는 상품을 잘 가져오는지 확인")
+    fun searchSubscriptionPeriod() {
+        // given
+        val searchDto = RequestProductSearchDto(
+            subscriptionStartDate = today.minusDays(20),
+            subscriptionEndDate = today
+        )
+
+        // when
+        val result = productSearchRepository.search(searchDto, unpaged)
+
+        // then
+        assertThat(result.size).isEqualTo(3)
+    }
+
+    @Test
+    @DisplayName("상품 검색 - 특정 기초자산을 포함하고 있는 상품을 잘 가져오는지 확인")
+    fun searchEquityNamesIn() {
+        // given
+        val equityNamesList = listOf("삼성전자", "S&P500")
+        val searchDto = RequestProductSearchDto(equityNames = equityNamesList)
+
+        // when
+        val result = productSearchRepository.search(searchDto, unpaged)
+
+        // then
+        assertThat(result.size).isEqualTo(1)
+        assertThat(result[0].equities).contains("삼성전자", "S&P500")
+    }
+
+    @Test
+    @DisplayName("상품 검색 - 종목 형으로만 이루어진 상품을 잘 가져오는지 확인")
+    fun searchEquityTypeEqSTOCK() {
+        // given
+        val searchDto = RequestProductSearchDto(equityType = UnderlyingAssetType.STOCK)
+
+        // when
+        val result = productSearchRepository.search(searchDto, unpaged)
+
+        // then
+        assertThat(result.size).isEqualTo(1)
+        assertThat(result[0].equities).contains("Tesla", "삼성전자", "NVIDIA")
+    }
+
+    @Test
+    @DisplayName("상품 검색 - 주가 지수 형으로만 이루어진 상품을 잘 가져오는지 확인")
+    fun searchEquityTypeEqINDEX() {
+        // given
+        val searchDto = RequestProductSearchDto(equityType = UnderlyingAssetType.INDEX)
+
+        // when
+        val result = productSearchRepository.search(searchDto, unpaged)
+
+        // then
+        assertThat(result.size).isEqualTo(1)
+        assertThat(result[0].equities).contains("S&P500", "HSCEI", "KOSPI200")
+    }
+
+    @Test
+    @DisplayName("상품 검색 - 주가 지수과 종목형이 섞여있는 상품을 잘 가져오는지 확인")
+    fun searchEquityTypeEqMIX() {
+        // given
+        val searchDto = RequestProductSearchDto(equityType = UnderlyingAssetType.MIX)
+
+        // when
+        val result = productSearchRepository.search(searchDto, unpaged)
+
+        // then
+        assertThat(result.size).isEqualTo(1)
+        assertThat(result[0].equities).contains("삼성전자", "S&P500", "KOSPI200")
+    }
+
+    @Test
+    @DisplayName("상품 검색 - 설정한 조기상환일 간격에 맞는 상품을 잘 가져오는지 확인")
+    fun searchRedemptionIntervalEq() {
+        // given
+        val earlyRepaymentDates = listOf(
+            today.plusMonths(6),
+            today.plusMonths(12),
+            today.plusMonths(18),
+            today.plusMonths(24),
+            today.plusMonths(30)
+        )
+        earlyRepaymentEvaluationDatesRepository.saveAll(
+            EarlyRepaymentEvaluationDatesMock.createList(product1, earlyRepaymentDates)
+        )
+
+        val searchDto = RequestProductSearchDto(redemptionInterval = 6)
+
+        // when
+        val result = productSearchRepository.search(searchDto, unpaged)
+
+        // then
+        assertThat(result.size).isEqualTo(1)
+        assertThat(result[0].equities).contains("삼성전자", "S&P500", "KOSPI200")
+    }
+}

--- a/src/test/kotlin/com/wl2c/elswhere/domain/product/repository/ProductTickerSymbolRepositoryTest.kt
+++ b/src/test/kotlin/com/wl2c/elswhere/domain/product/repository/ProductTickerSymbolRepositoryTest.kt
@@ -1,8 +1,5 @@
 package com.wl2c.elswhere.domain.product.repository
 
-import com.wl2c.elswhere.domain.product.model.MaturityEvaluationDateType
-import com.wl2c.elswhere.domain.product.model.ProductState
-import com.wl2c.elswhere.domain.product.model.ProductType
 import com.wl2c.elswhere.domain.product.model.UnderlyingAssetType
 import com.wl2c.elswhere.domain.product.model.entity.Product
 import com.wl2c.elswhere.mock.ProductMock
@@ -14,8 +11,6 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
-import java.math.BigDecimal
-import java.time.LocalDate
 
 @DataJpaTest
 class ProductTickerSymbolRepositoryTest @Autowired constructor(

--- a/src/test/kotlin/com/wl2c/elswhere/domain/product/repository/ProductTickerSymbolRepositoryTest.kt
+++ b/src/test/kotlin/com/wl2c/elswhere/domain/product/repository/ProductTickerSymbolRepositoryTest.kt
@@ -45,7 +45,7 @@ class ProductTickerSymbolRepositoryTest @Autowired constructor(
     @DisplayName("상품 id에 해당하는 상품 티커 심볼 리스트를 잘 가져오는지 확인")
     fun getListByProductId() {
         // given & when
-        val productTickerSymbolList = productTickerSymbolRepository.findAllByProductId(1L)
+        val productTickerSymbolList = productTickerSymbolRepository.findAllByProductId(product1.id!!)
 
         // then
         assertThat(productTickerSymbolList.size).isEqualTo(3)

--- a/src/test/kotlin/com/wl2c/elswhere/domain/product/repository/ProductTickerSymbolRepositoryTest.kt
+++ b/src/test/kotlin/com/wl2c/elswhere/domain/product/repository/ProductTickerSymbolRepositoryTest.kt
@@ -1,0 +1,77 @@
+package com.wl2c.elswhere.domain.product.repository
+
+import com.wl2c.elswhere.domain.product.model.MaturityEvaluationDateType
+import com.wl2c.elswhere.domain.product.model.ProductState
+import com.wl2c.elswhere.domain.product.model.ProductType
+import com.wl2c.elswhere.domain.product.model.UnderlyingAssetType
+import com.wl2c.elswhere.domain.product.model.entity.Product
+import com.wl2c.elswhere.mock.ProductMock
+import com.wl2c.elswhere.mock.ProductTickerSymbolMock
+import com.wl2c.elswhere.mock.TickerSymbolMock
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import java.math.BigDecimal
+import java.time.LocalDate
+
+@DataJpaTest
+class ProductTickerSymbolRepositoryTest @Autowired constructor(
+    private val productRepository: ProductRepository,
+    private val productTickerSymbolRepository: ProductTickerSymbolRepository,
+    private val tickerSymbolRepository: TickerSymbolRepository
+) {
+    private lateinit var product1: Product
+    private lateinit var product2: Product
+
+    @BeforeEach
+    fun setup() {
+        productTickerSymbolRepository.deleteAll()
+        tickerSymbolRepository.deleteAll()
+        productRepository.deleteAll()
+
+        val tickerSymbols = listOf(
+            TickerSymbolMock.create("005930.KS", "삼성전자", UnderlyingAssetType.STOCK),
+            TickerSymbolMock.create("^GSPC", "S&P500", UnderlyingAssetType.INDEX),
+            TickerSymbolMock.create("^KS200", "KOSPI200", UnderlyingAssetType.INDEX),
+        )
+        product1 = ProductMock.create()
+        product2 = ProductMock.create(name = "2호")
+
+        tickerSymbolRepository.saveAll(tickerSymbols)
+        productRepository.save(product1)
+        productRepository.save(product2)
+        productTickerSymbolRepository.saveAll(ProductTickerSymbolMock.createList(product1, listOf(tickerSymbols[0], tickerSymbols[1], tickerSymbols[2])))
+    }
+
+    @Test
+    @DisplayName("상품 id에 해당하는 상품 티커 심볼 리스트를 잘 가져오는지 확인")
+    fun getListByProductId() {
+        // given & when
+        val productTickerSymbolList = productTickerSymbolRepository.findAllByProductId(1L)
+
+        // then
+        assertThat(productTickerSymbolList.size).isEqualTo(3)
+        assertThat(productTickerSymbolList).allSatisfy {
+            assertThat(it.product.id).isEqualTo(product1.id)
+        }
+        assertThat(productTickerSymbolList)
+            .extracting("tickerSymbol.equityName")
+            .containsExactlyInAnyOrder("삼성전자", "S&P500", "KOSPI200")
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 상품 id로 조회하면 빈 리스트를 반환한다")
+    fun getEmptyListByNonExistentProductId() {
+        // given & when
+        val nonExistentProductId = 9999L
+        val productTickerSymbolList = productTickerSymbolRepository.findAllByProductId(nonExistentProductId)
+
+        // then
+        assertThat(productTickerSymbolList).isNotNull
+        assertThat(productTickerSymbolList).isEmpty()
+
+    }
+}

--- a/src/test/kotlin/com/wl2c/elswhere/mock/EarlyRepaymentEvaluationDatesMock.kt
+++ b/src/test/kotlin/com/wl2c/elswhere/mock/EarlyRepaymentEvaluationDatesMock.kt
@@ -1,0 +1,26 @@
+package com.wl2c.elswhere.mock
+
+import com.wl2c.elswhere.domain.product.model.entity.EarlyRepaymentEvaluationDates
+import com.wl2c.elswhere.domain.product.model.entity.Product
+import java.time.LocalDate
+
+object EarlyRepaymentEvaluationDatesMock {
+    fun create(
+        product: Product,
+        earlyRepaymentEvaluationDate: LocalDate
+    ): EarlyRepaymentEvaluationDates {
+        return EarlyRepaymentEvaluationDates(
+            product = product,
+            earlyRepaymentEvaluationDate = earlyRepaymentEvaluationDate
+        )
+    }
+
+    fun createList(
+        product: Product,
+        earlyRepaymentEvaluationDates: List<LocalDate>
+    ): List<EarlyRepaymentEvaluationDates> {
+        return earlyRepaymentEvaluationDates.map { date ->
+            create(product, date)
+        }
+    }
+}

--- a/src/test/kotlin/com/wl2c/elswhere/mock/ProductEquityVolatilityMock.kt
+++ b/src/test/kotlin/com/wl2c/elswhere/mock/ProductEquityVolatilityMock.kt
@@ -1,0 +1,18 @@
+package com.wl2c.elswhere.mock
+
+import com.wl2c.elswhere.domain.product.model.entity.ProductEquityVolatility
+import com.wl2c.elswhere.domain.product.model.entity.ProductTickerSymbol
+import java.math.BigDecimal
+
+object ProductEquityVolatilityMock {
+
+    fun create(
+        productTickerSymbol: ProductTickerSymbol,
+        volatility: BigDecimal = BigDecimal("0.25")
+    ): ProductEquityVolatility {
+        return ProductEquityVolatility(
+            productTickerSymbol = productTickerSymbol,
+            volatility = volatility
+        )
+    }
+}

--- a/src/test/kotlin/com/wl2c/elswhere/mock/ProductMock.kt
+++ b/src/test/kotlin/com/wl2c/elswhere/mock/ProductMock.kt
@@ -1,0 +1,71 @@
+package com.wl2c.elswhere.mock
+
+import com.wl2c.elswhere.domain.product.model.MaturityEvaluationDateType
+import com.wl2c.elswhere.domain.product.model.ProductState
+import com.wl2c.elswhere.domain.product.model.ProductType
+import com.wl2c.elswhere.domain.product.model.UnderlyingAssetType
+import com.wl2c.elswhere.domain.product.model.entity.Product
+import com.wl2c.elswhere.util.injectId
+import java.math.BigDecimal
+import java.time.LocalDate
+
+object ProductMock {
+
+    fun create(
+        issuer: String = "AA증권",
+        name: String = "1호",
+        issueNumber: Int? = 12345,
+        equities: String = "삼성전자 / S&P500 / KOSPI200",
+        equityCount: Int = 3,
+        knockIn: Int? = 45,
+        issuedDate: LocalDate = LocalDate.now().minusDays(1),
+        maturityDate: LocalDate = LocalDate.now().plusYears(3),
+        maturityEvaluationDate: LocalDate = LocalDate.now().plusYears(3).minusDays(5),
+        subscriptionStartDate: LocalDate = LocalDate.now().minusDays(14),
+        subscriptionEndDate: LocalDate = LocalDate.now().minusDays(1),
+        initialBasePriceEvaluationDate: LocalDate? = null,
+        maturityEvaluationDateType: MaturityEvaluationDateType = MaturityEvaluationDateType.SINGLE,
+        yieldIfConditionsMet: BigDecimal = BigDecimal("10.423"),
+        maximumLossRate: BigDecimal = BigDecimal("100.00"),
+        type: ProductType = ProductType.STEP_DOWN,
+        underlyingAssetType: UnderlyingAssetType = UnderlyingAssetType.MIX,
+        productFullInfo: String = "",
+        productInfo: String? = "95-90-85-80-75-50",
+        link: String = "",
+        remarks: String = "",
+        summaryInvestmentProspectusLink: String? = "",
+        earlyRepaymentEvaluationDates: String? = "",
+        volatilites: String? = "",
+        productState: ProductState = ProductState.ACTIVE
+    ): Product {
+        val product = Product(
+            issuer = issuer,
+            name = name,
+            issueNumber = issueNumber,
+            equities = equities,
+            equityCount = equityCount,
+            knockIn = knockIn,
+            issuedDate = issuedDate,
+            maturityDate = maturityDate,
+            maturityEvaluationDate = maturityEvaluationDate,
+            maturityEvaluationDateType = maturityEvaluationDateType,
+            yieldIfConditionsMet = yieldIfConditionsMet,
+            maximumLossRate = maximumLossRate,
+            subscriptionStartDate = subscriptionStartDate,
+            subscriptionEndDate = subscriptionEndDate,
+            type = type,
+            underlyingAssetType = underlyingAssetType,
+            productFullInfo = productFullInfo,
+            productInfo = productInfo,
+            link = link,
+            remarks = remarks,
+            summaryInvestmentProspectusLink = summaryInvestmentProspectusLink,
+            earlyRepaymentEvaluationDates = earlyRepaymentEvaluationDates,
+            volatilites = volatilites,
+            initialBasePriceEvaluationDate = initialBasePriceEvaluationDate,
+            productState = productState
+        )
+
+        return product
+    }
+}

--- a/src/test/kotlin/com/wl2c/elswhere/mock/ProductTickerSymbolMock.kt
+++ b/src/test/kotlin/com/wl2c/elswhere/mock/ProductTickerSymbolMock.kt
@@ -1,0 +1,29 @@
+package com.wl2c.elswhere.mock
+
+import com.wl2c.elswhere.domain.product.model.entity.Product
+import com.wl2c.elswhere.domain.product.model.entity.ProductTickerSymbol
+import com.wl2c.elswhere.domain.product.model.entity.TickerSymbol
+
+object ProductTickerSymbolMock {
+
+    fun create(
+        product: Product,
+        tickerSymbol: TickerSymbol,
+    ): ProductTickerSymbol {
+        val productTickerSymbol = ProductTickerSymbol(
+            product = product,
+            tickerSymbol = tickerSymbol
+        )
+
+        return productTickerSymbol
+    }
+
+    fun createList(
+        product: Product,
+        tickerSymbols: List<TickerSymbol>
+    ): List<ProductTickerSymbol> {
+        return tickerSymbols.map { ticker ->
+            create(product, ticker)
+        }
+    }
+}

--- a/src/test/kotlin/com/wl2c/elswhere/mock/TickerSymbolMock.kt
+++ b/src/test/kotlin/com/wl2c/elswhere/mock/TickerSymbolMock.kt
@@ -1,0 +1,19 @@
+package com.wl2c.elswhere.mock
+
+import com.wl2c.elswhere.domain.product.model.UnderlyingAssetType
+import com.wl2c.elswhere.domain.product.model.entity.TickerSymbol
+
+object TickerSymbolMock {
+
+    fun create(
+        tickerSymbol: String = "005930.KS",
+        equityName: String = "삼성전자",
+        underlyingAssetType: UnderlyingAssetType = UnderlyingAssetType.STOCK
+    ): TickerSymbol {
+        return TickerSymbol(
+            tickerSymbol = tickerSymbol,
+            equityName = equityName,
+            underlyingAssetType = underlyingAssetType
+        )
+    }
+}


### PR DESCRIPTION
## Issue 번호
#4

## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 리펙토링
- [ ] 버그 수정
- [x] 테스트 코드 작성
- [ ] 코드 스타일 업데이트
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트


## 작업 사항
1. Product 관련 repository들 Java -> Kotlin
    - (ProductRepository 외 6개)
2. 기존 ProductRepository의 상품 비교 조회 JPQL 쿼리 수정
3. Product 관련 repository들에 대한 테스트 코드 Java -> Kotlin 및 테스트 코드 추가 작성
4. Querydsl, Swagger 설정

## 기존 ProductRepository의 상품 비교 조회 JPQL 쿼리 수정
> 쿼리 설명: 현재 날짜를 기준으로 청약 가능한 상품들 중에서, 비교대상 id를 제외한 기초자산이 모두 같은 상품들을 select

dependent subquery 방식에서 join group by 방식으로 변경 (`select_type`: `dependent subquery` -> `simple`)

#### 수정 전 코드
```kotlin
    @Query("select p from Product p " +
            "where p.productState = 'ACTIVE' " +
            "and p.subscriptionEndDate >= CURRENT_DATE " +
            "and p.id <> :targetId " +
            "and p.equityCount = :targetEquityCount " +
            "and (select count(subpts.id) from ProductTickerSymbol subpts " +
            "      where subpts.product.id = p.id " +
            "      and subpts.tickerSymbol.tickerSymbol in :targetEquityTickerSymbols) = :targetEquityCount")
    fun findComparisonResults(@Param("targetId") targetId: Long,
                          @Param("targetEquityCount") targetEquityCount: Int,
                          @Param("targetEquityTickerSymbols") targetEquityTickerSymbols: List<String>): List<Product>
```

#### 수정 후 코드
```kotlin
    @Query("select p from Product p " +
            "join p.productTickerSymbols subpts on subpts.product.id = p.id " +
            "join subpts.tickerSymbol ts on ts.id = subpts.tickerSymbol.id " +
            "where p.productState = 'ACTIVE' " +
            "and p.subscriptionEndDate >= CURRENT_DATE " +
            "and p.id <> :targetId " +
            "and p.equityCount = :targetEquityCount " +
            "and ts.tickerSymbol IN :targetEquityTickerSymbols " +
            "group by p.id " +
            "having count(subpts.id) = :targetEquityCount ")
    fun findComparisonResults(@Param("targetId") targetId: Long,
                              @Param("targetEquityCount") targetEquityCount: Int,
                              @Param("targetEquityTickerSymbols") targetEquityTickerSymbols: List<String>): List<Product>
```

### 수정한 이유
`DEPENDENT SUBQUERY`
- from 절 이외의 부분에서 사용하는 서브 쿼리가 외부 쿼리에 값을 전달받아 실행되는 경우

`DEPENDENT SUBQUERY`의 문제점
- 서브 쿼리가 먼저 실행되지 못하고, 항상 외부 쿼리의 결과 값에 의존적이므로 전체 쿼리의 성능을 느리게 만들 수 있음

`SIMPLE`
- UNION이나 내부 쿼리가 없는 SELECT 문이라는 걸 의미함 -> 단순한 SELECT 구문으로만 작성된 경우


### 테스트
1만 -> 5만 -> 10만 -> 50만(product 테이블 기준)으로 점진적으로 `product`, `product_ticker_symbol` 테이블에 대한 더미 데이터를 생성해 테스트 진행

<img width="200" src="https://gist-image.s3.ap-northeast-2.amazonaws.com/elswhere/count-500K.png">

| dependent subquery | join groupby |
|--------------------|--------------|
| <img src="https://gist-image.s3.ap-northeast-2.amazonaws.com/elswhere/dependent+subquery-result-500K.png">         | <img src="https://gist-image.s3.ap-northeast-2.amazonaws.com/elswhere/join-groupby-result-500K.png">   |

- `5,00,000` rows 중 `2,804` rows 탐색에서 `3s 27ms` -> `2s 910ms` 정도로 소폭 성능이 향상되는 것을 확인할 수 있었음

### 인덱스 도입 고려
성능이 소폭 향상되었지만 만족스럽지 않아서 인덱스를 생성하여 성능 개선을 시도하였으나 

성능 개선이 이루어지지 못했음 (`추후 학습 후 다시 시도할 예정`)

```sql
CREATE INDEX idx_product_subscription_search
ON product (equity_count, subscription_end_date);
```
- 현재 생성한 인덱스의 경우 `EXPLAIN` 실행 계획을 보면 옵티마이저가 인덱스 대신 `PRIMARY` 키를 선택해서 사용하고 있음
- `FORCE INDEX`로 생성한 인덱스를 사용하도록 강제해도, 인덱스 적용 전보다 쿼리 속도가 현저히 느림
- `subscription_end_date`에 대해 실제 데이터와 유사한 환경으로 맞추기 위해서 날짜를 최대한 분배하도록 더미 데이터를 생성하여 카디널리티를 높였지만 동일함